### PR TITLE
fix options.env for custom set NODE_ENV in build command

### DIFF
--- a/packages/backpack-core/bin/build
+++ b/packages/backpack-core/bin/build
@@ -7,7 +7,7 @@ const fs = require('fs')
 process.on('SIGINT', process.exit)
 
 const options = {
-  env: 'production'
+  env: process.env.NODE_ENV || 'production'
 }
 
 const configPath = path.resolve('backpack.config.js')


### PR DESCRIPTION
i would like to use options.env = staging in build command however currently, the options.env is fixed in production only. Would it be possible to merge this pull request in your master. 