### PR TITLE
Migrate to webpack 4 🎉

### DIFF
--- a/packages/backpack-core/config/webpack.config.js
+++ b/packages/backpack-core/config/webpack.config.js
@@ -24,6 +24,10 @@ module.exports = (options) => {
   }
 
   return {
+    // Webpack v4 add a mode configuration option tells webpack to use its
+    // built-in optimizations accordingly.
+    // @see https://webpack.js.org/concepts/mode/
+    mode: options.env === 'development' ? 'development' : 'production',
     // Webpack can target multiple environments such as `node`,
     // `browser`, and even `electron`. Since Backpack is focused on Node,
     // we set the default target accordingly.
@@ -88,7 +92,6 @@ module.exports = (options) => {
         // It is focused on developer experience and fast rebuilds.
         {
           test: /\.json$/,
-          loader: require.resolve('json-loader')
         },
         // Process JS with Babel (transpiles ES6 code into ES5 code).
         {
@@ -108,8 +111,9 @@ module.exports = (options) => {
       // you use something like eslint or standard in your editor, you will
       // want to configure __DEV__ as a global variable accordingly.
       new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify(options.env),
-        '__DEV__': options.env === 'development'
+        // This is provided by the "mode" configuration option in webpack v4.
+        // 'process.env.NODE_ENV': JSON.stringify(options.env)
+        __DEV__: options.env === 'development'
       }),
       // In order to provide sourcemaps, we automagically insert this at the
       // top of each file using the BannerPlugin.
@@ -130,9 +134,14 @@ module.exports = (options) => {
       new FriendlyErrorsWebpackPlugin({
         clearConsole: options.env === 'development',
       }),
-      // The NoEmitOnErrorsPlugin plugin prevents Webpack
+    ],
+    // A few commonly used plugins have been removed from Webpack v4.
+    // Now instead, these plugins are avaliable as "optimizations".
+    // @see https://webpack.js.org/configuration/optimization/
+    optimization: {
+      // optimization.noEmitOnErrors prevents Webpack
       // from printing out compile time stats to the console.
-      new webpack.NoEmitOnErrorsPlugin()
-    ]
-  }
-}
+      noEmitOnErrors: true
+    }
+  };
+};

--- a/packages/backpack-core/package.json
+++ b/packages/backpack-core/package.json
@@ -16,12 +16,11 @@
     "babel-loader": "^7.1.0",
     "babel-preset-backpack": "^0.7.0",
     "cross-spawn": "^5.0.1",
-    "friendly-errors-webpack-plugin": "^1.6.1",
-    "json-loader": "^0.5.7",
+    "friendly-errors-webpack-plugin": "^1.7.0",
     "nodemon": "^1.11.0",
     "ramda": "^0.23.0",
     "source-map-support": "^0.4.15",
-    "webpack": "^3.11.0",
-    "webpack-node-externals": "^1.6.0"
+    "webpack": "^4.11.1",
+    "webpack-node-externals": "^1.7.2"
   }
 }


### PR DESCRIPTION
webpack v4 was released at the beginning of the year, this is a quick update of the webpack related packages and the config file. Unlike webpack v3, which was not a major upgrade over webpack v2, webpack v4 has a whole bunch of changes and features massive speed improvements.
See: https://medium.com/webpack/webpack-4-released-today-6cdb994702d4

## Config Changes

- Added "mode" configuration option 
- Removed "process.env.NODE_ENV" from DefinePlugin as it's now defined with "mode" configuration
- Moved "noEmitOnErrors" from plugins to optimizations.
- Removed "json-loader"

## Removed "json-loader"
webpack >= v2.0.0 has 'native'/direct JSON support. Since webpack >= v4.0.0 it's
a module.type (no JS wrapper needed anymore). It's suggested to remove json-loader.
See: https://github.com/webpack-contrib/json-loader/issues/65#issuecomment-368409135

## Updated Packages

- friendly-errors-webpack-plugin: 1.6.x -> 1.7.x
- webpack: 3.x -> 4.x
- webpack-node-externals: 1.6.x -> 1.7.x
