### PR TITLE
Fixed install instructions for typescript example

### DIFF
--- a/examples/with-typescript/README.md
+++ b/examples/with-typescript/README.md
@@ -5,8 +5,8 @@
 Download the example (or clone the whole project)[https://github.com/palmerhq/backpack.git]:
 
 ```bash
-curl https://codeload.github.com/palmerhq/backpack/tar.gz/master | tar -xz --strip=2 backpack-master/examples/with-typescript-webpack-config
-cd with-custom-webpack-config
+curl https://codeload.github.com/palmerhq/backpack/tar.gz/master | tar -xz --strip=2 backpack-master/examples/with-typescript
+cd with-typescript
 ```
 
 Install it and run:


### PR DESCRIPTION
Hi 👋
The install instructions for typescript example were using a wrong directory.
The instructions from the other examples seem to be correct.