### PR TITLE
Fix node externals

### DIFF
--- a/packages/backpack-core/config/webpack.config.js
+++ b/packages/backpack-core/config/webpack.config.js
@@ -41,15 +41,17 @@ module.exports = options => {
     // don't want to bundle its node_modules dependencies. This creates an externals
     // function that ignores node_modules when bundling in Webpack.
     // @see https://github.com/liady/webpack-node-externals
-    externals: nodeExternals({
-      modulesFromFile: true,
-      whitelist: [
-        /\.(eot|woff|woff2|ttf|otf)$/,
-        /\.(svg|png|jpg|jpeg|gif|ico|webm)$/,
-        /\.(mp4|mp3|ogg|swf|webp)$/,
-        /\.(css|scss|sass|less|styl)$/,
-      ],
-    }),
+    externals: [
+      nodeExternals({
+        modulesFromFile: true,
+        whitelist: [
+          /\.(eot|woff|woff2|ttf|otf)$/,
+          /\.(svg|png|jpg|jpeg|gif|ico|webm)$/,
+          /\.(mp4|mp3|ogg|swf|webp)$/,
+          /\.(css|scss|sass|less|styl)$/,
+        ],
+      })
+    ],
     // As of Webpack 2 beta, Webpack provides performance hints.
     // Since we are not targeting a browser, bundle size is not relevant.
     // Additionally, the performance hints clutter up our nice error messages.
@@ -122,10 +124,10 @@ module.exports = options => {
           // Is source-map-support installed as project dependency, or linked?
           require.resolve('source-map-support').indexOf(process.cwd()) === 0
             ? // If it's resolvable from the project root, it's a project dependency.
-              'source-map-support/register'
+            'source-map-support/register'
             : // It's not under the project, it's linked via lerna.
-              require.resolve('source-map-support/register')
-        }')`,
+            require.resolve('source-map-support/register')
+          }')`,
       }),
       // The FriendlyErrorsWebpackPlugin (when combined with source-maps)
       // gives Backpack its human-readable error messages.


### PR DESCRIPTION
The use of `webpack-node-externals` was incorrect as it was being used without being in an array (as described on  [their README](https://github.com/liady/webpack-node-externals/blob/master/README.md#quick-usage).

I tried out `backpack` today and noticed `node_modules` were not being ignored. After overriding the config with this simple fix `node_modules` were ignored as expected. Figured I would make a PR as after looking into the original config this seemed to be the wished for behavior.