### PR TITLE
Add semicolon to source-map-support banner to fix 'require() is not a function' error

### DIFF
--- a/packages/backpack-core/config/webpack.config.js
+++ b/packages/backpack-core/config/webpack.config.js
@@ -125,7 +125,7 @@ module.exports = options => {
               'source-map-support/register'
             : // It's not under the project, it's linked via lerna.
               require.resolve('source-map-support/register')
-        }')`,
+        }');`,
       }),
       // The FriendlyErrorsWebpackPlugin (when combined with source-maps)
       // gives Backpack its human-readable error messages.


### PR DESCRIPTION
I kept running into this error when executing my code that was bundled by Backpack:

```
/******/ (function(modules) { // webpackBootstrap
         ^
TypeError: require(...) is not a function
    at Object.<anonymous> (/Users/nkohari/Work/hireflow/packages/api/dist/bundle.js:2:10)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
    at internal/main/run_main_module.js:17:11
```

After some digging, I realized that it's a simple fix. Here's what's being generated on `master`:

```js
require('.../source-map-support/register.js')
/******/ (function(modules) { // webpackBootstrap
// ...
```

Node interprets this as passing the webpack output into the result of `require()` as an argument. If we change the banner to this fixes the issue (note the semicolon):

```js
require('.../source-map-support/register.js');
/******/ (function(modules) { // webpackBootstrap
// ...
```

This patch just adds that semicolon to the banner that's included at the top of the bundle. I'm not sure if there's just something strange about my Webpack config that makes this happen. However, there's no downside to adding the semicolon, so even if I've hit an edge case it seems like a good change.