### PR TITLE
Allow backpack.config.js to return promise as webpack config

### DIFF
--- a/packages/backpack-core/bin/build
+++ b/packages/backpack-core/bin/build
@@ -24,10 +24,20 @@ const serverConfig = userConfig.webpack
 
 process.on('SIGINT', process.exit)
 
-const serverCompiler = webpack(serverConfig)
+// If the user config function returns a promise, wait for it to resolve
+// before creating the webpack compiler.
+Promise.resolve(serverConfig)
+  .then(config => webpack(config))
+  .then(serverCompiler => {
+    serverCompiler.run((error, stats) => {
+      if (error || stats.hasErrors()) {
+        process.exitCode = 1;
+      }
+    })
+  })
+  .catch(err => {
+    console.error(err);
 
-serverCompiler.run((error, stats) => {
-  if (error || stats.hasErrors()) {
-    process.exitCode = 1;
-  }
-})
+    console.log('Build failed.');
+    process.exit(1);
+  });

--- a/packages/backpack-core/bin/dev
+++ b/packages/backpack-core/bin/dev
@@ -23,30 +23,29 @@ const serverConfig = userConfig.webpack
       ? userConfig.webpack(defaultConfig(options), options, webpack)
       : defaultConfig(options)
 
-function startDevServer(serverCompiler) {
-  process.on('SIGINT', process.exit)
+process.on('SIGINT', process.exit)
 
-  const startServer = () => {
-    const serverPaths = Object
-      .keys(serverCompiler.options.entry)
-      .map(entry => path.join(serverCompiler.options.output.path, `${entry}.js`))
-    nodemon({ script: serverPaths[0], watch: serverPaths, nodeArgs: process.argv.slice(2) })
-      .on('quit', process.exit)
-  }
-
-  const startServerOnce = once((err, stats) => {
-    if (err) return
-    startServer()
-  })
-  serverCompiler.watch(serverConfig.watchOptions || {}, startServerOnce)
+const startServer = serverCompiler => {
+  const serverPaths = Object
+    .keys(serverCompiler.options.entry)
+    .map(entry => path.join(serverCompiler.options.output.path, `${entry}.js`))
+  nodemon({ script: serverPaths[0], watch: serverPaths, nodeArgs: process.argv.slice(2) })
+    .on('quit', process.exit)
 }
 
 Promise
   .resolve(serverConfig)
   .then(config => webpack(config))
-  .then(serverCompiler => startDevServer(serverCompiler))
-  .catch(err => {
-    console.error(err);
+  .then(serverCompiler => {
+    const startServerOnce = once((err, stats) => {
+      if (err) return
+      startServer(serverCompiler)
+    })
 
-    process.exit(1);
-  });
+    serverCompiler.watch(serverConfig.watchOptions || {}, startServerOnce)
+  })
+  .catch(err => {
+    console.error(err)
+
+    process.exit(1)
+  })

--- a/packages/backpack-core/bin/dev
+++ b/packages/backpack-core/bin/dev
@@ -23,20 +23,30 @@ const serverConfig = userConfig.webpack
       ? userConfig.webpack(defaultConfig(options), options, webpack)
       : defaultConfig(options)
 
-process.on('SIGINT', process.exit)
+function startDevServer(serverCompiler) {
+  process.on('SIGINT', process.exit)
 
-const serverCompiler = webpack(serverConfig)
+  const startServer = () => {
+    const serverPaths = Object
+      .keys(serverCompiler.options.entry)
+      .map(entry => path.join(serverCompiler.options.output.path, `${entry}.js`))
+    nodemon({ script: serverPaths[0], watch: serverPaths, nodeArgs: process.argv.slice(2) })
+      .on('quit', process.exit)
+  }
 
-const startServer = () => {
-  const serverPaths = Object
-    .keys(serverCompiler.options.entry)
-    .map(entry => path.join(serverCompiler.options.output.path, `${entry}.js`))
-  nodemon({ script: serverPaths[0], watch: serverPaths, nodeArgs: process.argv.slice(2) })
-    .on('quit', process.exit)
+  const startServerOnce = once((err, stats) => {
+    if (err) return
+    startServer()
+  })
+  serverCompiler.watch(serverConfig.watchOptions || {}, startServerOnce)
 }
 
-const startServerOnce = once((err, stats) => {
-  if (err) return
-  startServer()
-})
-serverCompiler.watch(serverConfig.watchOptions || {}, startServerOnce)
+Promise
+  .resolve(serverConfig)
+  .then(config => webpack(config))
+  .then(serverCompiler => startDevServer(serverCompiler))
+  .catch(err => {
+    console.error(err);
+
+    process.exit(1);
+  });


### PR DESCRIPTION
Since Webpack CLI supports user configuration file to return a promise that will resolve to the configuration object, it makes sense that backpack should support it as well.

There seems to be a consensus that if one is using webpack's node api instead of the cli, it is their responsibility to decide how the config is obtained. So, in this case, it is backpack's responsibility to create the compiler after all the config has been resolved.

I am sure there is some interest in having this feature in backpack (https://github.com/jaredpalmer/backpack/issues/97).