### PR TITLE
Add explicit extension on sub module imports

### DIFF
--- a/packages/babel-preset-backpack/index.js
+++ b/packages/babel-preset-backpack/index.js
@@ -48,7 +48,7 @@ module.exports = function() {
           regenerator: true,
           // Resolve the Babel runtime relative to the config.
           absoluteRuntime: path.dirname(
-            require.resolve('@babel/runtime/package')
+            require.resolve('@babel/runtime/package.json')
           ),
         },
       ],


### PR DESCRIPTION
Node.js recommends sub module imports should end with explicit extension: https://nodejs.org/api/esm.html#esm_experimental_json_modules

Requiring extension-less `package` breaks `@babel/runtime` 7.12.0.

Context: https://github.com/babel/babel/issues/12178