### PR TITLE
Typo fix

### DIFF
--- a/packages/babel-preset-backpack/README.md
+++ b/packages/babel-preset-backpack/README.md
@@ -1,6 +1,6 @@
 # babel-preset-backpack
 
-This package includes the [Babel](https://babeljs.io) preset used by [Backpack](https://github/com/palmerhq/backpack)
+This package includes the [Babel](https://babeljs.io) preset used by [Backpack](https://github.com/palmerhq/backpack)
 
 ## Usage in Backpack Projects
 


### PR DESCRIPTION
Fixed a `/` to a `.` in the README to fix a broken URL